### PR TITLE
Fix `displayName` and name lifecycle functions

### DIFF
--- a/examples/controlled-input/src/ControlledInput.purs
+++ b/examples/controlled-input/src/ControlledInput.purs
@@ -10,7 +10,7 @@ import React.Basic.DOM.Events as Events
 
 component :: ReactComponent {}
 component = react
-  { displayName: "Counter"
+  { displayName: "ControlledInput"
   , initialState: { value: "hello world", timeStamp: Nothing }
   , receiveProps: \_ _ _ -> pure unit
   , render: \_ state setState ->

--- a/src/React/Basic.js
+++ b/src/React/Basic.js
@@ -4,15 +4,16 @@ var React = require("react");
 var Fragment = React.Fragment || "div";
 
 exports.component_ = function(spec) {
-  function Component(props) {
+  var Component = function constructor(props) {
     this.state = spec.initialState;
     return this;
-  }
+  };
+
   Component.prototype = Object.create(React.Component.prototype);
 
-  Component.prototype.displayName = spec.displayName;
+  Component.displayName = spec.displayName;
 
-  Component.prototype.componentDidMount = function() {
+  Component.prototype.componentDidMount = function componentDidMount() {
     var this_ = this;
     spec.receiveProps(this.props, this.state, function(newState) {
       return function() {
@@ -21,7 +22,9 @@ exports.component_ = function(spec) {
     });
   };
 
-  Component.prototype.componentWillReceiveProps = function(newProps) {
+  Component.prototype.componentWillReceiveProps = function componentWillReceiveProps(
+    newProps
+  ) {
     var this_ = this;
     spec.receiveProps(newProps, this.state, function(newState) {
       return function() {
@@ -30,7 +33,7 @@ exports.component_ = function(spec) {
     });
   };
 
-  Component.prototype.render = function() {
+  Component.prototype.render = function render() {
     var this_ = this;
     return spec.render(this.props, this.state, function(newState) {
       return function() {


### PR DESCRIPTION
- `displayName` was not being set correctly, so it wasn't doing anything
- named lifecycle functions just makes debugging slightly better (call stack will display the lifecycle function name instead of another "anonymous"