### PR TITLE
Add psc-package.json

### DIFF
--- a/psc-package.json
+++ b/psc-package.json
@@ -1,0 +1,14 @@
+{
+  "name": "purescript-react-basic",
+  "set": "psc-0.12.0",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "effect",
+    "functions",
+    "nullable",
+    "prelude",
+    "record",
+    "typelevel-prelude",
+    "unsafe-coerce"
+  ]
+}


### PR DESCRIPTION
It's handy to have it for development. I can see some reasons against having both `psc-package.json` and `bower.json` in the repo (deps confusion), but I don't know whether it's worthy to remove `bower.json`.