### PR TITLE
Fix createElementKeyed_ to refer correct 'createElement'

### DIFF
--- a/src/React/Basic.js
+++ b/src/React/Basic.js
@@ -52,7 +52,7 @@ exports.createElement_ = function(el, attrs) {
   );
 };
 
-exports.createElementKeyed_ = React.createElement;
+exports.createElementKeyed_ = exports.createElement_;
 
 exports.fragment = function(children) {
   return React.createElement.apply(null, [Fragment, {}].concat(children));


### PR DESCRIPTION
I might just be very confused here, I didn't try using `createElementKeyed` myself, and none of examples are using it, so it's just an educated guess (TODO: add example).

There are following foreign imports in `React.Basic`:

```haskell
foreign import createElement_ :: forall props. Fn2 (ReactComponent { | props }) { | props } JSX
foreign import createElementKeyed_ :: forall props. Fn2 (ReactComponent { | props }) { key :: String | props } JSX
```

They are pretty much the same, except that one allows to set the `key` property. Implementations are defined as follows:

```haskell
exports.createElement_ = function(el, attrs) {
  return React.createElement.apply(
    null,
    [el, attrs].concat((attrs && attrs.children) || [])
  );
};

exports.createElementKeyed_ = React.createElement;
```

The `React.createElement` seems like a typo, as it won't even match a type. It should be `exports.createElement_` instead.