### PR TITLE
Use "componentDidUpdate"

### DIFF
--- a/examples/component/src/Container.purs
+++ b/examples/component/src/Container.purs
@@ -10,7 +10,7 @@ component = React.stateless { displayName: "Container", render }
     render _ =
       R.div
         { children:
-            [ React.element ToggleButton.component { on: true }
-            , React.element ToggleButton.component { on: false }
+            [ React.element ToggleButton.component { label: "A" }
+            , React.element ToggleButton.component { label: "B" }
             ]
         }

--- a/examples/component/src/ToggleButton.purs
+++ b/examples/component/src/ToggleButton.purs
@@ -7,20 +7,27 @@ import React.Basic.DOM as R
 import React.Basic.Events as Events
 
 type Props =
-  { on :: Boolean
+  { label :: String
   }
 
 component :: React.Component Props
 component = React.component { displayName: "ToggleButton", initialState, receiveProps, render }
   where
     initialState =
-      { on: false }
+      { on: false
+      }
 
-    receiveProps { props, setState } =
-      setState _ { on = props.on }
+    receiveProps _ =
+      pure unit
 
-    render { state, setState } =
+    render { props, state, setState } =
       R.button
-        { onClick: Events.handler_ (setState \s -> s { on = not s.on })
-        , children: [ R.text if state.on then "On" else "Off" ]
+        { onClick: Events.handler_ do
+            setState \s -> s { on = not s.on }
+        , children:
+            [ R.text props.label
+            , R.text if state.on
+                       then " On"
+                       else " Off"
+            ]
         }

--- a/src/React/Basic.js
+++ b/src/React/Basic.js
@@ -21,20 +21,18 @@ exports.component_ = function(spec) {
       state: this.state,
       setState: this._setState,
       setStateThen: this._setState,
-      instance_: this,
+      instance_: this
     });
   };
 
-  Component.prototype.componentWillReceiveProps = function componentWillReceiveProps(
-    newProps
-  ) {
+  Component.prototype.componentDidUpdate = function componentDidUpdate() {
     spec.receiveProps({
       isFirstMount: false,
-      props: newProps,
+      props: this.props,
       state: this.state,
       setState: this._setState,
       setStateThen: this._setState,
-      instance_: this,
+      instance_: this
     });
   };
 
@@ -44,7 +42,7 @@ exports.component_ = function(spec) {
       state: this.state,
       setState: this._setState,
       setStateThen: this._setState,
-      instance_: this,
+      instance_: this
     });
   };
 


### PR DESCRIPTION
...instead of `componentWillReceiveProps`.

Originally `componentWillReceiveProps` was used to allow `setState` calls to resolve before the next render, in order to avoid double-rendering. This is a bit of an edge case and updates which cause double-rendering aren't considered "best practice" with React in anyway (I'll explain below).

Changing to `componentDidUpdate` makes the update behavior consistent with first mount (in both cases a render has already happened when `receiveProps` is called and the DOM update is complete), allowing functions like `findDOMNode` to reliably select the rendered element which represents the current state of the component's props. Without this change you either have to avoid ever altering the root node or run the logic in a `setTimeout` (not reliable).

--------

_On the note about "best practice" --_

Props shoudn't determine state without a good reason, i.e. some info that _isn't available directly in the props themselves_ and is _expensive to compute_. When a prop is copied directly into state every time it changes (or even just sometimes), it produces two sources for that value. Which one "owns" it? If the component state is the source of truth, changes to props will get ignored. If the parent owns it, copying it into the component state is pointless. If the parent owns it but the child needs to be able to change it, the parent should also be passing down a callback for updating the value it owns, rather than having a child clone it.

If the value is expensive to compute but otherwise available in the props, prefer a memoizing helper (a Memoize component that takes a [render prop](https://reactjs.org/docs/render-props.html) is a good idea). If the value is not readily available from the props alone (maybe an API call or user input is needed), the update is already going to be asynchronous and double-rendering is unavoidable (even desirable, indicate that loading state).

More info: [You probably don't need derived state](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html)