### PR TITLE
Provide previous props/state to didUpdate

### DIFF
--- a/src/React/Basic.js
+++ b/src/React/Basic.js
@@ -16,6 +16,13 @@ exports.createComponent = (function() {
     return self;
   }
 
+  function componentDidMount() {
+    var didMount = this.$$spec.didMount;
+    if (didMount !== undefined) {
+      didMount(this.toSelf())();
+    }
+  }
+
   function shouldComponentUpdate(nextProps, nextState) {
     var shouldUpdate = this.$$spec.shouldUpdate;
     return shouldUpdate === undefined
@@ -24,13 +31,6 @@ exports.createComponent = (function() {
         nextProps: nextProps.$$props,
         nextState: nextState === null ? null : nextState.$$state
       });
-  }
-
-  function componentDidMount() {
-    var didMount = this.$$spec.didMount;
-    if (didMount !== undefined) {
-      didMount(this.toSelf())();
-    }
   }
 
   function componentDidUpdate(prevProps, prevState) {
@@ -140,8 +140,8 @@ exports.make = function(_unionDict) {
         initialState: $$spec.initialState,
         update: $$spec.update,
         render: $$spec.render,
-        shouldUpdate: $$spec.shouldUpdate,
         didMount: $$spec.didMount,
+        shouldUpdate: $$spec.shouldUpdate,
         didUpdate: $$spec.didUpdate,
         willUnmount: $$spec.willUnmount
       };
@@ -191,8 +191,8 @@ exports.toReactComponent = function(_unionDict) {
           initialState: $$spec.initialState,
           update: $$spec.update,
           render: $$spec.render,
-          shouldUpdate: $$spec.shouldUpdate,
           didMount: $$spec.didMount,
+          shouldUpdate: $$spec.shouldUpdate,
           didUpdate: $$spec.didUpdate,
           willUnmount: $$spec.willUnmount
         };

--- a/src/React/Basic.js
+++ b/src/React/Basic.js
@@ -20,9 +20,10 @@ exports.createComponent = (function() {
     var shouldUpdate = this.$$spec.shouldUpdate;
     return shouldUpdate === undefined
       ? true
-      : shouldUpdate(this.toSelf())(nextProps.$$props)(
-          nextState === null ? null : nextState.$$state
-        );
+      : shouldUpdate(this.toSelf())({
+        nextProps: nextProps.$$props,
+        nextState: nextState === null ? null : nextState.$$state
+      });
   }
 
   function componentDidMount() {
@@ -32,10 +33,13 @@ exports.createComponent = (function() {
     }
   }
 
-  function componentDidUpdate() {
+  function componentDidUpdate(prevProps, prevState) {
     var didUpdate = this.$$spec.didUpdate;
     if (didUpdate !== undefined) {
-      didUpdate(this.toSelf())();
+      didUpdate(this.toSelf())({
+        prevProps: prevProps.$$props,
+        prevState: prevState === null ? null : prevState.$$state
+      })();
     }
   }
 

--- a/src/React/Basic.purs
+++ b/src/React/Basic.purs
@@ -58,10 +58,10 @@ import Type.Row (class Union)
 -- |   - Side effects requested are only invoked _after_ any corrosponding state update has completed its render cycle and the changes have been applied. This means it is safe to interact with the DOM in a side effect, for example.
 -- | - `render`
 -- |   - Takes a current snapshot of the component (`Self`) and converts it to renderable `JSX`.
--- | - `shouldUpdate`
--- |   - Can be useful for performance optimizations. Rarely necessary.
 -- | - `didMount`
 -- |   - The React component's `componentDidMount` lifecycle. Useful for initiating an action on first mount, such as fetching data from a server.
+-- | - `shouldUpdate`
+-- |   - Can be useful for performance optimizations. Rarely necessary.
 -- | - `didUpdate`
 -- |   - The React component's `componentDidUpdate` lifecycle. Rarely necessary.
 -- | - `willUnmount`

--- a/src/React/Basic.purs
+++ b/src/React/Basic.purs
@@ -110,9 +110,9 @@ type ComponentSpec props state action =
   ( initialState :: state
   , update       :: Self props state action -> action -> StateUpdate props state action
   , render       :: Self props state action -> JSX
-  , shouldUpdate :: Self props state action -> props -> state -> Boolean
   , didMount     :: Self props state action -> Effect Unit
-  , didUpdate    :: Self props state action -> Effect Unit
+  , shouldUpdate :: Self props state action -> { nextProps :: props, nextState :: state } -> Boolean
+  , didUpdate    :: Self props state action -> { prevProps :: props, prevState :: state } -> Effect Unit
   , willUnmount  :: Self props state action -> Effect Unit
   )
 

--- a/src/React/Basic/Compat.purs
+++ b/src/React/Basic/Compat.purs
@@ -28,7 +28,7 @@ component { displayName, initialState, receiveProps, render } =
   toReactComponent identity (createComponent displayName)
     { initialState: initialState
     , didMount: receiveProps <<< selfToLegacySelf
-    , didUpdate: receiveProps <<< selfToLegacySelf
+    , didUpdate: const <<< receiveProps <<< selfToLegacySelf
     , update: \self stateUpdate -> Update (stateUpdate self.state)
     , render: render <<< selfToLegacySelf
     }


### PR DESCRIPTION
Closes #68

`shouldUpdate` has similar props and I've found them confusing as nothing names them as "next" or "prev", so I changed both to receive a record which at least has the property names visible. What do you think, @akheron?