### PR TITLE
Remove update/action code and re-expose React's setState functions

### DIFF
--- a/examples/async/src/AsyncCounter.purs
+++ b/examples/async/src/AsyncCounter.purs
@@ -5,9 +5,10 @@ import Prelude
 import Effect.Aff (Milliseconds(..), delay)
 import Effect.Class (liftEffect)
 import Effect.Console (log)
-import React.Basic (Component, JSX, StateUpdate(..), capture_, createComponent, fragment, keyed, make)
+import React.Basic (Component, JSX, createComponent, fragment, keyed, make)
 import React.Basic.Components.Async (asyncWithLoader)
 import React.Basic.DOM as R
+import React.Basic.DOM.Events (capture_)
 
 component :: Component Props
 component = createComponent "AsyncCounter"
@@ -16,17 +17,10 @@ type Props =
   { label :: String
   }
 
-data Action
-  = Increment
-
 asyncCounter :: Props -> JSX
-asyncCounter = make component { initialState, update, render }
+asyncCounter = make component { initialState, render }
   where
-    initialState = { counter: 0 }
-
-    update self = case _ of
-      Increment ->
-        Update self.state { counter = self.state.counter + 1 }
+    initialState = 0
 
     render self =
       fragment
@@ -36,16 +30,16 @@ asyncCounter = make component { initialState, update, render }
             , R.li_ [ R.text "\"done\" should only be logged to the console once for any loading period (in-flight requests get cancelled as the next request starts)" ]
             ]
         , R.button
-            { onClick: capture_ self Increment
-            , children: [ R.text (self.props.label <> ": " <> show self.state.counter) ]
+            { onClick: capture_ $ self.setState (_ + 1)
+            , children: [ R.text (self.props.label <> ": " <> show self.state) ]
             }
         , R.text " "
-        , keyed (show self.state.counter) $
+        , keyed (show self.state) $
             asyncWithLoader (R.text "Loading...") do
               liftEffect $ log "start"
               delay $ Milliseconds 2000.0
               liftEffect $ log "done"
-              pure $ R.text $ "Done: " <> show self.state.counter
+              pure $ R.text $ "Done: " <> show self.state
         ]
 
 

--- a/examples/component/package.json
+++ b/examples/component/package.json
@@ -4,6 +4,6 @@
     "react-dom": "^16.4.2"
   },
   "devDependencies": {
-    "browserify": "^16.2.2"
+    "browserify": "16.2.3"
   }
 }

--- a/examples/component/src/ToggleButton.purs
+++ b/examples/component/src/ToggleButton.purs
@@ -3,8 +3,9 @@ module ToggleButton where
 import Prelude
 
 import Effect.Console (log)
-import React.Basic (Component, JSX, StateUpdate(..), capture_, createComponent, make)
+import React.Basic (Component, JSX, createComponent, make, readState)
 import React.Basic.DOM as R
+import React.Basic.DOM.Events (capture_)
 
 component :: Component Props
 component = createComponent "ToggleButton"
@@ -13,25 +14,18 @@ type Props =
   { label :: String
   }
 
-data Action
-  = Toggle
-
 toggleButton :: Props -> JSX
 toggleButton = make component
   { initialState:
       { on: false
       }
 
-  , update: \self -> case _ of
-      Toggle ->
-        UpdateAndSideEffects
-          self.state { on = not self.state.on }
-          \nextSelf -> do
-            log $ "next state: " <> show nextSelf.state
-
   , render: \self ->
       R.button
-        { onClick: capture_ self Toggle
+        { onClick: capture_ $
+            self.setStateThen _ { on = not self.state.on } do
+              nextState <- readState self
+              log $ "next state: " <> show nextState
         , children:
             [ R.text self.props.label
             , R.text if self.state.on

--- a/examples/controlled-input/src/ControlledInput.purs
+++ b/examples/controlled-input/src/ControlledInput.purs
@@ -3,19 +3,16 @@ module ControlledInput where
 import Prelude
 
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
-import React.Basic (Component, JSX, StateUpdate(..), capture, createComponent, make)
+import React.Basic (Component, JSX, createComponent, make)
 import React.Basic as React
 import React.Basic.DOM as R
-import React.Basic.DOM.Events (targetValue, timeStamp)
+import React.Basic.DOM.Events (capture, targetValue, timeStamp)
 import React.Basic.Events (merge)
 
 component :: Component Props
 component = createComponent "ControlledInput"
 
 type Props = Unit
-
-data Action
-  = ValueChanged String Number
 
 controlledInput :: Props -> JSX
 controlledInput = make component
@@ -24,19 +21,16 @@ controlledInput = make component
       , timestamp: Nothing
       }
 
-  , update: \self -> case _ of
-      ValueChanged value timestamp ->
-        Update self.state
-          { value = value
-          , timestamp = Just timestamp
-          }
-
   , render: \self ->
       React.fragment
         [ R.input
             { onChange:
-                capture self (merge { targetValue, timeStamp })
-                  \{ timeStamp, targetValue } -> ValueChanged (fromMaybe "" targetValue) timeStamp
+                capture (merge { targetValue, timeStamp })
+                  \{ timeStamp, targetValue } ->
+                    self.setState _
+                      { value = fromMaybe "" targetValue
+                      , timestamp = Just timeStamp
+                      }
             , value: self.state.value
             }
         , R.p_ [ R.text ("Current value = " <> show self.state.value) ]

--- a/examples/counter/src/Counter.purs
+++ b/examples/counter/src/Counter.purs
@@ -2,8 +2,9 @@ module Counter where
 
 import Prelude
 
-import React.Basic (Component, JSX, StateUpdate(..), capture_, createComponent, make)
+import React.Basic (Component, JSX, createComponent, make)
 import React.Basic.DOM as R
+import React.Basic.DOM.Events (capture_)
 
 component :: Component Props
 component = createComponent "Counter"
@@ -12,20 +13,13 @@ type Props =
   { label :: String
   }
 
-data Action
-  = Increment
-
 counter :: Props -> JSX
-counter = make component { initialState, update, render }
+counter = make component { initialState, render }
   where
     initialState = { counter: 0 }
 
-    update self = case _ of
-      Increment ->
-        Update self.state { counter = self.state.counter + 1 }
-
     render self =
       R.button
-        { onClick: capture_ self Increment
+        { onClick: capture_ $ self.setState \s -> s { counter = s.counter + 1 }
         , children: [ R.text (self.props.label <> ": " <> show self.state.counter) ]
         }

--- a/generated-docs/React/Basic/Compat.md
+++ b/generated-docs/React/Basic/Compat.md
@@ -12,7 +12,7 @@ type Component = ReactComponent
 #### `component`
 
 ``` purescript
-component :: forall props state. { displayName :: String, initialState :: {  | state }, receiveProps :: { props :: {  | props }, state :: {  | state }, setState :: ({  | state } -> {  | state }) -> Effect Unit } -> Effect Unit, render :: { props :: {  | props }, state :: {  | state }, setState :: ({  | state } -> {  | state }) -> Effect Unit } -> JSX } -> ReactComponent {  | props }
+component :: forall props state. { displayName :: String, initialState :: {  | state }, receiveProps :: Self {  | props } {  | state } -> Effect Unit, render :: Self {  | props } {  | state } -> JSX } -> ReactComponent {  | props }
 ```
 
 Supports a common subset of the v2 API to ease the upgrade process
@@ -27,6 +27,27 @@ Supports a common subset of the v2 API to ease the upgrade process
 
 
 ### Re-exported from React.Basic:
+
+#### `Self`
+
+``` purescript
+type Self props state = { props :: props, state :: state, setState :: (state -> state) -> Effect Unit, setStateThen :: (state -> state) -> Effect Unit -> Effect Unit, instance_ :: ReactComponentInstance props state }
+```
+
+`Self` represents the component instance at a particular point in time.
+
+- `props`
+  - A snapshot of `props` taken when this `Self` was created.
+- `state`
+  - A snapshot of `state` taken when this `Self` was created.
+- `setState`
+  - Update the component's state using the given function.
+- `setStateThen`
+  - Update the component's state using the given function. The given effects are performed after any resulting rerenders are completed. Be careful to avoid using stale props or state in the effect callback. Use `readProps` or `readState` to aquire the latest values.
+- `instance_`
+  - Unsafe escape hatch to the underlying component instance (`this` in the JavaScript React paradigm). Avoid as much as possible, but it's still frequently better than rewriting an entire component in JavaScript.
+
+__*See also:* `ComponentSpec`, `send`, `capture`, `readProps`, `readState`__
 
 #### `JSX`
 

--- a/generated-docs/React/Basic/DOM.md
+++ b/generated-docs/React/Basic/DOM.md
@@ -74,7 +74,7 @@ __*Note:* Relies on `ReactDOM.unmountComponentAtNode`__
 #### `findDOMNode`
 
 ``` purescript
-findDOMNode :: ReactComponentInstance -> Effect (Either Error Node)
+findDOMNode :: forall props state. ReactComponentInstance props state -> Effect (Either Error Node)
 ```
 
 Returns the current DOM node associated with the given
@@ -157,7 +157,7 @@ type Props_var = (children :: Array JSX)
 #### `Props_ul`
 
 ``` purescript
-type Props_ul = (children :: Array JSX, "type" :: String)
+type Props_ul = (children :: Array JSX, type :: String)
 ```
 
 #### `Props_u`
@@ -241,7 +241,7 @@ type Props_table = (children :: Array JSX, summary :: String, width :: String)
 #### `Props_svg`
 
 ``` purescript
-type Props_svg = (accentHeight :: String, accumulate :: String, additive :: String, alignmentBaseline :: String, allowReorder :: String, alphabetic :: String, amplitude :: String, arabicForm :: String, ascent :: String, attributeName :: String, attributeType :: String, autoReverse :: String, azimuth :: String, baseFrequency :: String, baseProfile :: String, baselineShift :: String, bbox :: String, begin :: String, bias :: String, by :: String, calcMode :: String, capHeight :: String, children :: Array JSX, clip :: String, clipPath :: String, clipPathUnits :: String, clipRule :: String, color :: String, colorInterpolation :: String, colorInterpolationFilters :: String, colorProfile :: String, colorRendering :: String, contentScriptType :: String, contentStyleType :: String, cursor :: String, cx :: String, cy :: String, d :: String, decelerate :: String, descent :: String, diffuseConstant :: String, direction :: String, display :: String, divisor :: String, dominantBaseline :: String, dur :: String, dx :: String, dy :: String, edgeMode :: String, elevation :: String, enableBackground :: String, end :: String, exponent :: String, externalResourcesRequired :: String, fill :: String, fillOpacity :: String, fillRule :: String, filter :: String, filterRes :: String, filterUnits :: String, floodColor :: String, floodOpacity :: String, focusable :: String, fontFamily :: String, fontSize :: String, fontSizeAdjust :: String, fontStretch :: String, fontStyle :: String, fontVariant :: String, fontWeight :: String, format :: String, from :: String, fx :: String, fy :: String, g1 :: String, g2 :: String, glyphName :: String, glyphOrientationHorizontal :: String, glyphOrientationVertical :: String, glyphRef :: String, gradientTransform :: String, gradientUnits :: String, hanging :: String, height :: String, horizAdvX :: String, horizOriginX :: String, ideographic :: String, imageRendering :: String, "in" :: String, in2 :: String, intercept :: String, k :: String, k1 :: String, k2 :: String, k3 :: String, k4 :: String, kernelMatrix :: String, kernelUnitLength :: String, kerning :: String, keyPoints :: String, keySplines :: String, keyTimes :: String, lengthAdjust :: String, letterSpacing :: String, lightingColor :: String, limitingConeAngle :: String, local :: String, markerEnd :: String, markerHeight :: String, markerMid :: String, markerStart :: String, markerUnits :: String, markerWidth :: String, mask :: String, maskContentUnits :: String, maskUnits :: String, mathematical :: String, mode :: String, numOctaves :: String, offset :: String, opacity :: String, operator :: String, order :: String, orient :: String, orientation :: String, origin :: String, overflow :: String, overlinePosition :: String, overlineThickness :: String, paintOrder :: String, panose1 :: String, pathLength :: String, patternContentUnits :: String, patternTransform :: String, patternUnits :: String, pointerEvents :: String, points :: String, pointsAtX :: String, pointsAtY :: String, pointsAtZ :: String, preserveAlpha :: String, preserveAspectRatio :: String, primitiveUnits :: String, r :: String, radius :: String, refX :: String, refY :: String, renderingIntent :: String, repeatCount :: String, repeatDur :: String, requiredExtensions :: String, requiredFeatures :: String, restart :: String, result :: String, rotate :: String, rx :: String, ry :: String, scale :: String, seed :: String, shapeRendering :: String, slope :: String, spacing :: String, specularConstant :: String, specularExponent :: String, speed :: String, spreadMethod :: String, startOffset :: String, stdDeviation :: String, stemh :: String, stemv :: String, stitchTiles :: String, stopColor :: String, stopOpacity :: String, strikethroughPosition :: String, strikethroughThickness :: String, string :: String, stroke :: String, strokeDasharray :: String, strokeDashoffset :: String, strokeLinecap :: String, strokeLinejoin :: String, strokeMiterlimit :: String, strokeOpacity :: String, strokeWidth :: String, surfaceScale :: String, systemLanguage :: String, tableValues :: String, targetX :: String, targetY :: String, textAnchor :: String, textDecoration :: String, textLength :: String, textRendering :: String, to :: String, transform :: String, u1 :: String, u2 :: String, underlinePosition :: String, underlineThickness :: String, unicode :: String, unicodeBidi :: String, unicodeRange :: String, unitsPerEm :: String, vAlphabetic :: String, vHanging :: String, vIdeographic :: String, vMathematical :: String, values :: String, vectorEffect :: String, version :: String, vertAdvY :: String, vertOriginX :: String, vertOriginY :: String, viewBox :: String, viewTarget :: String, visibility :: String, width :: String, widths :: String, wordSpacing :: String, writingMode :: String, x :: String, x1 :: String, x2 :: String, xChannelSelector :: String, xHeight :: String, xlinkActuate :: String, xlinkArcrole :: String, xlinkHref :: String, xlinkRole :: String, xlinkShow :: String, xlinkTitle :: String, xlinkType :: String, xmlBase :: String, xmlLang :: String, xmlSpace :: String, xmlns :: String, xmlnsXlink :: String, y :: String, y1 :: String, y2 :: String, yChannelSelector :: String, z :: String, zoomAndPan :: String)
+type Props_svg = (accentHeight :: String, accumulate :: String, additive :: String, alignmentBaseline :: String, allowReorder :: String, alphabetic :: String, amplitude :: String, arabicForm :: String, ascent :: String, attributeName :: String, attributeType :: String, autoReverse :: String, azimuth :: String, baseFrequency :: String, baseProfile :: String, baselineShift :: String, bbox :: String, begin :: String, bias :: String, by :: String, calcMode :: String, capHeight :: String, children :: Array JSX, clip :: String, clipPath :: String, clipPathUnits :: String, clipRule :: String, color :: String, colorInterpolation :: String, colorInterpolationFilters :: String, colorProfile :: String, colorRendering :: String, contentScriptType :: String, contentStyleType :: String, cursor :: String, cx :: String, cy :: String, d :: String, decelerate :: String, descent :: String, diffuseConstant :: String, direction :: String, display :: String, divisor :: String, dominantBaseline :: String, dur :: String, dx :: String, dy :: String, edgeMode :: String, elevation :: String, enableBackground :: String, end :: String, exponent :: String, externalResourcesRequired :: String, fill :: String, fillOpacity :: String, fillRule :: String, filter :: String, filterRes :: String, filterUnits :: String, floodColor :: String, floodOpacity :: String, focusable :: String, fontFamily :: String, fontSize :: String, fontSizeAdjust :: String, fontStretch :: String, fontStyle :: String, fontVariant :: String, fontWeight :: String, format :: String, from :: String, fx :: String, fy :: String, g1 :: String, g2 :: String, glyphName :: String, glyphOrientationHorizontal :: String, glyphOrientationVertical :: String, glyphRef :: String, gradientTransform :: String, gradientUnits :: String, hanging :: String, height :: String, horizAdvX :: String, horizOriginX :: String, ideographic :: String, imageRendering :: String, in :: String, in2 :: String, intercept :: String, k :: String, k1 :: String, k2 :: String, k3 :: String, k4 :: String, kernelMatrix :: String, kernelUnitLength :: String, kerning :: String, keyPoints :: String, keySplines :: String, keyTimes :: String, lengthAdjust :: String, letterSpacing :: String, lightingColor :: String, limitingConeAngle :: String, local :: String, markerEnd :: String, markerHeight :: String, markerMid :: String, markerStart :: String, markerUnits :: String, markerWidth :: String, mask :: String, maskContentUnits :: String, maskUnits :: String, mathematical :: String, mode :: String, numOctaves :: String, offset :: String, opacity :: String, operator :: String, order :: String, orient :: String, orientation :: String, origin :: String, overflow :: String, overlinePosition :: String, overlineThickness :: String, paintOrder :: String, panose1 :: String, pathLength :: String, patternContentUnits :: String, patternTransform :: String, patternUnits :: String, pointerEvents :: String, points :: String, pointsAtX :: String, pointsAtY :: String, pointsAtZ :: String, preserveAlpha :: String, preserveAspectRatio :: String, primitiveUnits :: String, r :: String, radius :: String, refX :: String, refY :: String, renderingIntent :: String, repeatCount :: String, repeatDur :: String, requiredExtensions :: String, requiredFeatures :: String, restart :: String, result :: String, rotate :: String, rx :: String, ry :: String, scale :: String, seed :: String, shapeRendering :: String, slope :: String, spacing :: String, specularConstant :: String, specularExponent :: String, speed :: String, spreadMethod :: String, startOffset :: String, stdDeviation :: String, stemh :: String, stemv :: String, stitchTiles :: String, stopColor :: String, stopOpacity :: String, strikethroughPosition :: String, strikethroughThickness :: String, string :: String, stroke :: String, strokeDasharray :: String, strokeDashoffset :: String, strokeLinecap :: String, strokeLinejoin :: String, strokeMiterlimit :: String, strokeOpacity :: String, strokeWidth :: String, surfaceScale :: String, systemLanguage :: String, tableValues :: String, targetX :: String, targetY :: String, textAnchor :: String, textDecoration :: String, textLength :: String, textRendering :: String, to :: String, transform :: String, u1 :: String, u2 :: String, underlinePosition :: String, underlineThickness :: String, unicode :: String, unicodeBidi :: String, unicodeRange :: String, unitsPerEm :: String, vAlphabetic :: String, vHanging :: String, vIdeographic :: String, vMathematical :: String, values :: String, vectorEffect :: String, version :: String, vertAdvY :: String, vertOriginX :: String, vertOriginY :: String, viewBox :: String, viewTarget :: String, visibility :: String, width :: String, widths :: String, wordSpacing :: String, writingMode :: String, x :: String, x1 :: String, x2 :: String, xChannelSelector :: String, xHeight :: String, xlinkActuate :: String, xlinkArcrole :: String, xlinkHref :: String, xlinkRole :: String, xlinkShow :: String, xlinkTitle :: String, xlinkType :: String, xmlBase :: String, xmlLang :: String, xmlSpace :: String, xmlns :: String, xmlnsXlink :: String, y :: String, y1 :: String, y2 :: String, yChannelSelector :: String, z :: String, zoomAndPan :: String)
 ```
 
 #### `Props_sup`
@@ -265,7 +265,7 @@ type Props_sub = (children :: Array JSX)
 #### `Props_style`
 
 ``` purescript
-type Props_style = (children :: Array JSX, media :: String, nonce :: String, title :: String, "type" :: String)
+type Props_style = (children :: Array JSX, media :: String, nonce :: String, title :: String, type :: String)
 ```
 
 #### `Props_strong`
@@ -283,7 +283,7 @@ type Props_span = (children :: Array JSX)
 #### `Props_source`
 
 ``` purescript
-type Props_source = (media :: String, sizes :: String, src :: String, "type" :: String)
+type Props_source = (media :: String, sizes :: String, src :: String, type :: String)
 ```
 
 #### `Props_small`
@@ -313,7 +313,7 @@ type Props_section = (children :: Array JSX)
 #### `Props_script`
 
 ``` purescript
-type Props_script = (async :: Boolean, children :: Array JSX, defer :: Boolean, integrity :: String, nonce :: String, src :: String, "type" :: String)
+type Props_script = (async :: Boolean, children :: Array JSX, defer :: Boolean, integrity :: String, nonce :: String, src :: String, type :: String)
 ```
 
 #### `Props_samp`
@@ -385,7 +385,7 @@ type Props_picture = (children :: Array JSX)
 #### `Props_param`
 
 ``` purescript
-type Props_param = (name :: String, "type" :: String, value :: String)
+type Props_param = (name :: String, type :: String, value :: String)
 ```
 
 #### `Props_p`
@@ -415,13 +415,13 @@ type Props_optgroup = (children :: Array JSX, disabled :: Boolean, label :: Stri
 #### `Props_ol`
 
 ``` purescript
-type Props_ol = (children :: Array JSX, reversed :: Boolean, start :: Number, "type" :: String)
+type Props_ol = (children :: Array JSX, reversed :: Boolean, start :: Number, type :: String)
 ```
 
 #### `Props_object`
 
 ``` purescript
-type Props_object = (children :: Array JSX, "data" :: String, form :: String, height :: String, name :: String, "type" :: String, width :: String)
+type Props_object = (children :: Array JSX, data :: String, form :: String, height :: String, name :: String, type :: String, width :: String)
 ```
 
 #### `Props_noscript`
@@ -487,13 +487,13 @@ type Props_main = (children :: Array JSX)
 #### `Props_link`
 
 ``` purescript
-type Props_link = (color :: String, href :: String, integrity :: String, media :: String, nonce :: String, rel :: String, scope :: String, sizes :: String, target :: String, title :: String, "type" :: String)
+type Props_link = (color :: String, href :: String, integrity :: String, media :: String, nonce :: String, rel :: String, scope :: String, sizes :: String, target :: String, title :: String, type :: String)
 ```
 
 #### `Props_li`
 
 ``` purescript
-type Props_li = (children :: Array JSX, "type" :: String, value :: String)
+type Props_li = (children :: Array JSX, type :: String, value :: String)
 ```
 
 #### `Props_legend`
@@ -529,7 +529,7 @@ type Props_ins = (children :: Array JSX, cite :: String)
 #### `Props_input`
 
 ``` purescript
-type Props_input = (accept :: String, alt :: String, autoCapitalize :: String, autoCorrect :: String, autoSave :: String, checked :: Boolean, defaultChecked :: String, defaultValue :: String, disabled :: Boolean, form :: String, height :: String, list :: String, max :: Number, min :: Number, multiple :: Boolean, name :: String, onChange :: EventHandler, pattern :: String, placeholder :: String, required :: Boolean, results :: String, size :: Number, src :: String, step :: String, title :: String, "type" :: String, value :: String, width :: String)
+type Props_input = (accept :: String, alt :: String, autoCapitalize :: String, autoCorrect :: String, autoSave :: String, checked :: Boolean, defaultChecked :: String, defaultValue :: String, disabled :: Boolean, form :: String, height :: String, list :: String, max :: Number, min :: Number, multiple :: Boolean, name :: String, onChange :: EventHandler, pattern :: String, placeholder :: String, required :: Boolean, results :: String, size :: Number, src :: String, step :: String, title :: String, type :: String, value :: String, width :: String)
 ```
 
 #### `Props_img`
@@ -649,7 +649,7 @@ type Props_fieldset = (children :: Array JSX, disabled :: Boolean, form :: Strin
 #### `Props_embed`
 
 ``` purescript
-type Props_embed = (height :: String, src :: String, "type" :: String, width :: String)
+type Props_embed = (height :: String, src :: String, type :: String, width :: String)
 ```
 
 #### `Props_em`
@@ -757,7 +757,7 @@ type Props_canvas = (children :: Array JSX, height :: String, width :: String)
 #### `Props_button`
 
 ``` purescript
-type Props_button = (children :: Array JSX, disabled :: Boolean, form :: String, name :: String, "type" :: String, value :: String)
+type Props_button = (children :: Array JSX, disabled :: Boolean, form :: String, name :: String, type :: String, value :: String)
 ```
 
 #### `Props_br`
@@ -823,7 +823,7 @@ type Props_article = (children :: Array JSX)
 #### `Props_area`
 
 ``` purescript
-type Props_area = (alt :: String, coords :: String, download :: String, href :: String, rel :: String, shape :: String, target :: String, "type" :: String)
+type Props_area = (alt :: String, coords :: String, download :: String, href :: String, rel :: String, shape :: String, target :: String, type :: String)
 ```
 
 #### `Props_address`
@@ -841,7 +841,7 @@ type Props_abbr = (children :: Array JSX, title :: String)
 #### `Props_a`
 
 ``` purescript
-type Props_a = (children :: Array JSX, coords :: String, download :: String, href :: String, name :: String, onClick :: EventHandler, rel :: String, shape :: String, target :: String, "type" :: String)
+type Props_a = (children :: Array JSX, coords :: String, download :: String, href :: String, name :: String, onClick :: EventHandler, rel :: String, shape :: String, target :: String, type :: String)
 ```
 
 #### `wbr`

--- a/generated-docs/React/Basic/DOM/Events.md
+++ b/generated-docs/React/Basic/DOM/Events.md
@@ -2,6 +2,29 @@
 
 This module defines safe DOM event function and property accessors.
 
+#### `capture`
+
+``` purescript
+capture :: forall a. EventFn SyntheticEvent a -> (a -> Effect Unit) -> EventHandler
+```
+
+Create a capturing\* `EventHandler` to send an action when an event occurs. For
+more complicated event handlers requiring `Effect`, use `handler` from `React.Basic.Events`.
+
+__\*calls `preventDefault` and `stopPropagation`__
+
+__*See also:* `update`, `capture_`, `monitor`, `React.Basic.Events`__
+
+#### `capture_`
+
+``` purescript
+capture_ :: Effect Unit -> EventHandler
+```
+
+Like `capture`, but for actions which don't need to extract information from the Event.
+
+__*See also:* `update`, `capture`, `monitor_`__
+
 #### `bubbles`
 
 ``` purescript

--- a/generated-docs/React/Basic/DOM/Generated.md
+++ b/generated-docs/React/Basic/DOM/Generated.md
@@ -7,7 +7,7 @@ THIS FILE IS GENERATED -- DO NOT EDIT IT
 #### `Props_a`
 
 ``` purescript
-type Props_a = (children :: Array JSX, coords :: String, download :: String, href :: String, name :: String, onClick :: EventHandler, rel :: String, shape :: String, target :: String, "type" :: String)
+type Props_a = (children :: Array JSX, coords :: String, download :: String, href :: String, name :: String, onClick :: EventHandler, rel :: String, shape :: String, target :: String, type :: String)
 ```
 
 #### `a`
@@ -61,7 +61,7 @@ address_ :: Array JSX -> JSX
 #### `Props_area`
 
 ``` purescript
-type Props_area = (alt :: String, coords :: String, download :: String, href :: String, rel :: String, shape :: String, target :: String, "type" :: String)
+type Props_area = (alt :: String, coords :: String, download :: String, href :: String, rel :: String, shape :: String, target :: String, type :: String)
 ```
 
 #### `area`
@@ -241,7 +241,7 @@ br :: forall attrs attrs_. Union attrs attrs_ (SharedProps Props_br) => {  | att
 #### `Props_button`
 
 ``` purescript
-type Props_button = (children :: Array JSX, disabled :: Boolean, form :: String, name :: String, "type" :: String, value :: String)
+type Props_button = (children :: Array JSX, disabled :: Boolean, form :: String, name :: String, type :: String, value :: String)
 ```
 
 #### `button`
@@ -559,7 +559,7 @@ em_ :: Array JSX -> JSX
 #### `Props_embed`
 
 ``` purescript
-type Props_embed = (height :: String, src :: String, "type" :: String, width :: String)
+type Props_embed = (height :: String, src :: String, type :: String, width :: String)
 ```
 
 #### `embed`
@@ -901,7 +901,7 @@ img :: forall attrs attrs_. Union attrs attrs_ (SharedProps Props_img) => {  | a
 #### `Props_input`
 
 ``` purescript
-type Props_input = (accept :: String, alt :: String, autoCapitalize :: String, autoCorrect :: String, autoSave :: String, checked :: Boolean, defaultChecked :: String, defaultValue :: String, disabled :: Boolean, form :: String, height :: String, list :: String, max :: Number, min :: Number, multiple :: Boolean, name :: String, onChange :: EventHandler, pattern :: String, placeholder :: String, required :: Boolean, results :: String, size :: Number, src :: String, step :: String, title :: String, "type" :: String, value :: String, width :: String)
+type Props_input = (accept :: String, alt :: String, autoCapitalize :: String, autoCorrect :: String, autoSave :: String, checked :: Boolean, defaultChecked :: String, defaultValue :: String, disabled :: Boolean, form :: String, height :: String, list :: String, max :: Number, min :: Number, multiple :: Boolean, name :: String, onChange :: EventHandler, pattern :: String, placeholder :: String, required :: Boolean, results :: String, size :: Number, src :: String, step :: String, title :: String, type :: String, value :: String, width :: String)
 ```
 
 #### `input`
@@ -1003,7 +1003,7 @@ legend_ :: Array JSX -> JSX
 #### `Props_li`
 
 ``` purescript
-type Props_li = (children :: Array JSX, "type" :: String, value :: String)
+type Props_li = (children :: Array JSX, type :: String, value :: String)
 ```
 
 #### `li`
@@ -1021,7 +1021,7 @@ li_ :: Array JSX -> JSX
 #### `Props_link`
 
 ``` purescript
-type Props_link = (color :: String, href :: String, integrity :: String, media :: String, nonce :: String, rel :: String, scope :: String, sizes :: String, target :: String, title :: String, "type" :: String)
+type Props_link = (color :: String, href :: String, integrity :: String, media :: String, nonce :: String, rel :: String, scope :: String, sizes :: String, target :: String, title :: String, type :: String)
 ```
 
 #### `link`
@@ -1207,7 +1207,7 @@ noscript_ :: Array JSX -> JSX
 #### `Props_object`
 
 ``` purescript
-type Props_object = (children :: Array JSX, "data" :: String, form :: String, height :: String, name :: String, "type" :: String, width :: String)
+type Props_object = (children :: Array JSX, data :: String, form :: String, height :: String, name :: String, type :: String, width :: String)
 ```
 
 #### `object`
@@ -1225,7 +1225,7 @@ object_ :: Array JSX -> JSX
 #### `Props_ol`
 
 ``` purescript
-type Props_ol = (children :: Array JSX, reversed :: Boolean, start :: Number, "type" :: String)
+type Props_ol = (children :: Array JSX, reversed :: Boolean, start :: Number, type :: String)
 ```
 
 #### `ol`
@@ -1315,7 +1315,7 @@ p_ :: Array JSX -> JSX
 #### `Props_param`
 
 ``` purescript
-type Props_param = (name :: String, "type" :: String, value :: String)
+type Props_param = (name :: String, type :: String, value :: String)
 ```
 
 #### `param`
@@ -1525,7 +1525,7 @@ samp_ :: Array JSX -> JSX
 #### `Props_script`
 
 ``` purescript
-type Props_script = (async :: Boolean, children :: Array JSX, defer :: Boolean, integrity :: String, nonce :: String, src :: String, "type" :: String)
+type Props_script = (async :: Boolean, children :: Array JSX, defer :: Boolean, integrity :: String, nonce :: String, src :: String, type :: String)
 ```
 
 #### `script`
@@ -1615,7 +1615,7 @@ small_ :: Array JSX -> JSX
 #### `Props_source`
 
 ``` purescript
-type Props_source = (media :: String, sizes :: String, src :: String, "type" :: String)
+type Props_source = (media :: String, sizes :: String, src :: String, type :: String)
 ```
 
 #### `source`
@@ -1663,7 +1663,7 @@ strong_ :: Array JSX -> JSX
 #### `Props_style`
 
 ``` purescript
-type Props_style = (children :: Array JSX, media :: String, nonce :: String, title :: String, "type" :: String)
+type Props_style = (children :: Array JSX, media :: String, nonce :: String, title :: String, type :: String)
 ```
 
 #### `style`
@@ -1735,7 +1735,7 @@ sup_ :: Array JSX -> JSX
 #### `Props_svg`
 
 ``` purescript
-type Props_svg = (accentHeight :: String, accumulate :: String, additive :: String, alignmentBaseline :: String, allowReorder :: String, alphabetic :: String, amplitude :: String, arabicForm :: String, ascent :: String, attributeName :: String, attributeType :: String, autoReverse :: String, azimuth :: String, baseFrequency :: String, baseProfile :: String, baselineShift :: String, bbox :: String, begin :: String, bias :: String, by :: String, calcMode :: String, capHeight :: String, children :: Array JSX, clip :: String, clipPath :: String, clipPathUnits :: String, clipRule :: String, color :: String, colorInterpolation :: String, colorInterpolationFilters :: String, colorProfile :: String, colorRendering :: String, contentScriptType :: String, contentStyleType :: String, cursor :: String, cx :: String, cy :: String, d :: String, decelerate :: String, descent :: String, diffuseConstant :: String, direction :: String, display :: String, divisor :: String, dominantBaseline :: String, dur :: String, dx :: String, dy :: String, edgeMode :: String, elevation :: String, enableBackground :: String, end :: String, exponent :: String, externalResourcesRequired :: String, fill :: String, fillOpacity :: String, fillRule :: String, filter :: String, filterRes :: String, filterUnits :: String, floodColor :: String, floodOpacity :: String, focusable :: String, fontFamily :: String, fontSize :: String, fontSizeAdjust :: String, fontStretch :: String, fontStyle :: String, fontVariant :: String, fontWeight :: String, format :: String, from :: String, fx :: String, fy :: String, g1 :: String, g2 :: String, glyphName :: String, glyphOrientationHorizontal :: String, glyphOrientationVertical :: String, glyphRef :: String, gradientTransform :: String, gradientUnits :: String, hanging :: String, height :: String, horizAdvX :: String, horizOriginX :: String, ideographic :: String, imageRendering :: String, "in" :: String, in2 :: String, intercept :: String, k :: String, k1 :: String, k2 :: String, k3 :: String, k4 :: String, kernelMatrix :: String, kernelUnitLength :: String, kerning :: String, keyPoints :: String, keySplines :: String, keyTimes :: String, lengthAdjust :: String, letterSpacing :: String, lightingColor :: String, limitingConeAngle :: String, local :: String, markerEnd :: String, markerHeight :: String, markerMid :: String, markerStart :: String, markerUnits :: String, markerWidth :: String, mask :: String, maskContentUnits :: String, maskUnits :: String, mathematical :: String, mode :: String, numOctaves :: String, offset :: String, opacity :: String, operator :: String, order :: String, orient :: String, orientation :: String, origin :: String, overflow :: String, overlinePosition :: String, overlineThickness :: String, paintOrder :: String, panose1 :: String, pathLength :: String, patternContentUnits :: String, patternTransform :: String, patternUnits :: String, pointerEvents :: String, points :: String, pointsAtX :: String, pointsAtY :: String, pointsAtZ :: String, preserveAlpha :: String, preserveAspectRatio :: String, primitiveUnits :: String, r :: String, radius :: String, refX :: String, refY :: String, renderingIntent :: String, repeatCount :: String, repeatDur :: String, requiredExtensions :: String, requiredFeatures :: String, restart :: String, result :: String, rotate :: String, rx :: String, ry :: String, scale :: String, seed :: String, shapeRendering :: String, slope :: String, spacing :: String, specularConstant :: String, specularExponent :: String, speed :: String, spreadMethod :: String, startOffset :: String, stdDeviation :: String, stemh :: String, stemv :: String, stitchTiles :: String, stopColor :: String, stopOpacity :: String, strikethroughPosition :: String, strikethroughThickness :: String, string :: String, stroke :: String, strokeDasharray :: String, strokeDashoffset :: String, strokeLinecap :: String, strokeLinejoin :: String, strokeMiterlimit :: String, strokeOpacity :: String, strokeWidth :: String, surfaceScale :: String, systemLanguage :: String, tableValues :: String, targetX :: String, targetY :: String, textAnchor :: String, textDecoration :: String, textLength :: String, textRendering :: String, to :: String, transform :: String, u1 :: String, u2 :: String, underlinePosition :: String, underlineThickness :: String, unicode :: String, unicodeBidi :: String, unicodeRange :: String, unitsPerEm :: String, vAlphabetic :: String, vHanging :: String, vIdeographic :: String, vMathematical :: String, values :: String, vectorEffect :: String, version :: String, vertAdvY :: String, vertOriginX :: String, vertOriginY :: String, viewBox :: String, viewTarget :: String, visibility :: String, width :: String, widths :: String, wordSpacing :: String, writingMode :: String, x :: String, x1 :: String, x2 :: String, xChannelSelector :: String, xHeight :: String, xlinkActuate :: String, xlinkArcrole :: String, xlinkHref :: String, xlinkRole :: String, xlinkShow :: String, xlinkTitle :: String, xlinkType :: String, xmlBase :: String, xmlLang :: String, xmlSpace :: String, xmlns :: String, xmlnsXlink :: String, y :: String, y1 :: String, y2 :: String, yChannelSelector :: String, z :: String, zoomAndPan :: String)
+type Props_svg = (accentHeight :: String, accumulate :: String, additive :: String, alignmentBaseline :: String, allowReorder :: String, alphabetic :: String, amplitude :: String, arabicForm :: String, ascent :: String, attributeName :: String, attributeType :: String, autoReverse :: String, azimuth :: String, baseFrequency :: String, baseProfile :: String, baselineShift :: String, bbox :: String, begin :: String, bias :: String, by :: String, calcMode :: String, capHeight :: String, children :: Array JSX, clip :: String, clipPath :: String, clipPathUnits :: String, clipRule :: String, color :: String, colorInterpolation :: String, colorInterpolationFilters :: String, colorProfile :: String, colorRendering :: String, contentScriptType :: String, contentStyleType :: String, cursor :: String, cx :: String, cy :: String, d :: String, decelerate :: String, descent :: String, diffuseConstant :: String, direction :: String, display :: String, divisor :: String, dominantBaseline :: String, dur :: String, dx :: String, dy :: String, edgeMode :: String, elevation :: String, enableBackground :: String, end :: String, exponent :: String, externalResourcesRequired :: String, fill :: String, fillOpacity :: String, fillRule :: String, filter :: String, filterRes :: String, filterUnits :: String, floodColor :: String, floodOpacity :: String, focusable :: String, fontFamily :: String, fontSize :: String, fontSizeAdjust :: String, fontStretch :: String, fontStyle :: String, fontVariant :: String, fontWeight :: String, format :: String, from :: String, fx :: String, fy :: String, g1 :: String, g2 :: String, glyphName :: String, glyphOrientationHorizontal :: String, glyphOrientationVertical :: String, glyphRef :: String, gradientTransform :: String, gradientUnits :: String, hanging :: String, height :: String, horizAdvX :: String, horizOriginX :: String, ideographic :: String, imageRendering :: String, in :: String, in2 :: String, intercept :: String, k :: String, k1 :: String, k2 :: String, k3 :: String, k4 :: String, kernelMatrix :: String, kernelUnitLength :: String, kerning :: String, keyPoints :: String, keySplines :: String, keyTimes :: String, lengthAdjust :: String, letterSpacing :: String, lightingColor :: String, limitingConeAngle :: String, local :: String, markerEnd :: String, markerHeight :: String, markerMid :: String, markerStart :: String, markerUnits :: String, markerWidth :: String, mask :: String, maskContentUnits :: String, maskUnits :: String, mathematical :: String, mode :: String, numOctaves :: String, offset :: String, opacity :: String, operator :: String, order :: String, orient :: String, orientation :: String, origin :: String, overflow :: String, overlinePosition :: String, overlineThickness :: String, paintOrder :: String, panose1 :: String, pathLength :: String, patternContentUnits :: String, patternTransform :: String, patternUnits :: String, pointerEvents :: String, points :: String, pointsAtX :: String, pointsAtY :: String, pointsAtZ :: String, preserveAlpha :: String, preserveAspectRatio :: String, primitiveUnits :: String, r :: String, radius :: String, refX :: String, refY :: String, renderingIntent :: String, repeatCount :: String, repeatDur :: String, requiredExtensions :: String, requiredFeatures :: String, restart :: String, result :: String, rotate :: String, rx :: String, ry :: String, scale :: String, seed :: String, shapeRendering :: String, slope :: String, spacing :: String, specularConstant :: String, specularExponent :: String, speed :: String, spreadMethod :: String, startOffset :: String, stdDeviation :: String, stemh :: String, stemv :: String, stitchTiles :: String, stopColor :: String, stopOpacity :: String, strikethroughPosition :: String, strikethroughThickness :: String, string :: String, stroke :: String, strokeDasharray :: String, strokeDashoffset :: String, strokeLinecap :: String, strokeLinejoin :: String, strokeMiterlimit :: String, strokeOpacity :: String, strokeWidth :: String, surfaceScale :: String, systemLanguage :: String, tableValues :: String, targetX :: String, targetY :: String, textAnchor :: String, textDecoration :: String, textLength :: String, textRendering :: String, to :: String, transform :: String, u1 :: String, u2 :: String, underlinePosition :: String, underlineThickness :: String, unicode :: String, unicodeBidi :: String, unicodeRange :: String, unitsPerEm :: String, vAlphabetic :: String, vHanging :: String, vIdeographic :: String, vMathematical :: String, values :: String, vectorEffect :: String, version :: String, vertAdvY :: String, vertOriginX :: String, vertOriginY :: String, viewBox :: String, viewTarget :: String, visibility :: String, width :: String, widths :: String, wordSpacing :: String, writingMode :: String, x :: String, x1 :: String, x2 :: String, xChannelSelector :: String, xHeight :: String, xlinkActuate :: String, xlinkArcrole :: String, xlinkHref :: String, xlinkRole :: String, xlinkShow :: String, xlinkTitle :: String, xlinkType :: String, xmlBase :: String, xmlLang :: String, xmlSpace :: String, xmlns :: String, xmlnsXlink :: String, y :: String, y1 :: String, y2 :: String, yChannelSelector :: String, z :: String, zoomAndPan :: String)
 ```
 
 #### `svg`
@@ -1981,7 +1981,7 @@ u_ :: Array JSX -> JSX
 #### `Props_ul`
 
 ``` purescript
-type Props_ul = (children :: Array JSX, "type" :: String)
+type Props_ul = (children :: Array JSX, type :: String)
 ```
 
 #### `ul`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1498,12 +1498,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1518,17 +1520,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1645,7 +1650,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1657,6 +1663,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1671,6 +1678,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1678,12 +1686,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1702,6 +1712,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1782,7 +1793,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1794,6 +1806,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1915,6 +1928,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/React/Basic.js
+++ b/src/React/Basic.js
@@ -8,10 +8,24 @@ exports.createComponent = (function() {
   // (`this`-dependent, defined outside `createComponent`
   // for a slight performance boost)
   function toSelf() {
+    var instance = this;
+    var setStateThen = function(update) {
+      return function(effects) {
+        return function() {
+          instance.setState(function(state) {
+            return { $$state: update(state.$$state) };
+          }, effects);
+        };
+      };
+    };
     var self = {
-      props: this.props.$$props,
-      state: this.state === null ? null : this.state.$$state,
-      instance_: this
+      props: instance.props.$$props,
+      state: instance.state === null ? null : instance.state.$$state,
+      setState: function(update) {
+        return setStateThen(update)(undefined);
+      },
+      setStateThen: setStateThen,
+      instance_: instance
     };
     return self;
   }
@@ -28,9 +42,9 @@ exports.createComponent = (function() {
     return shouldUpdate === undefined
       ? true
       : shouldUpdate(this.toSelf())({
-        nextProps: nextProps.$$props,
-        nextState: nextState === null ? null : nextState.$$state
-      });
+          nextProps: nextProps.$$props,
+          nextState: nextState === null ? null : nextState.$$state
+        });
   }
 
   function componentDidUpdate(prevProps, prevState) {
@@ -84,42 +98,6 @@ exports.createComponent = (function() {
   };
 })();
 
-exports.send_ = function(buildStateUpdate) {
-  return function(self, action) {
-    if (!self.instance_.$$mounted) {
-      exports.warningUnmountedComponentAction(self, action);
-      return;
-    }
-    if (self.instance_.$$spec.update === undefined) {
-      exports.warningDefaultUpdate(self, action);
-      return;
-    }
-    var sideEffects = null;
-    self.instance_.setState(
-      function(s) {
-        var setStateContext = self.instance_.toSelf();
-        setStateContext.state = s.$$state;
-        var updates = buildStateUpdate(
-          self.instance_.$$spec.update(setStateContext)(action)
-        );
-        if (updates.effects !== null) {
-          sideEffects = updates.effects;
-        }
-        if (updates.state !== null && updates.state !== s.$$state) {
-          return { $$state: updates.state };
-        } else {
-          return null;
-        }
-      },
-      function() {
-        if (sideEffects !== null) {
-          sideEffects(this.toSelf())();
-        }
-      }
-    );
-  };
-};
-
 exports.readProps = function(self) {
   return function() {
     return self.instance_.props.$$props;
@@ -138,7 +116,6 @@ exports.make = function(_unionDict) {
     return function($$spec) {
       var $$specPadded = {
         initialState: $$spec.initialState,
-        update: $$spec.update,
         render: $$spec.render,
         didMount: $$spec.didMount,
         shouldUpdate: $$spec.shouldUpdate,
@@ -189,7 +166,6 @@ exports.toReactComponent = function(_unionDict) {
       return function($$spec) {
         var $$specPadded = {
           initialState: $$spec.initialState,
-          update: $$spec.update,
           render: $$spec.render,
           didMount: $$spec.didMount,
           shouldUpdate: $$spec.shouldUpdate,
@@ -217,33 +193,4 @@ exports.toReactComponent = function(_unionDict) {
       };
     };
   };
-};
-
-exports.warningDefaultUpdate = function(self, action) {
-  console.error(
-    "A " +
-      exports.displayNameFromSelf(self) +
-      " component received an action but has no `update` function defined. Override the default `update` function to handle this action."
-  );
-  console.error("Self:", self);
-  console.error("Action:", action);
-};
-
-exports.warningUnmountedComponentAction = function(self, action) {
-  console.error(
-    "An unmounted " +
-      exports.displayNameFromSelf(self) +
-      " component received the action below. Actions received by unmounted components usually indicate a memory leak. Make sure to unsubscribe from any async work in `willUnmount`."
-  );
-  console.error("Self:", self);
-  console.error("Action:", action);
-};
-
-exports.warningFailedAsyncAction = function(self, error) {
-  console.error(
-    "An async action failed in a " +
-      exports.displayNameFromSelf(self) +
-      " component."
-  );
-  console.error(error);
 };

--- a/src/React/Basic/Compat.purs
+++ b/src/React/Basic/Compat.purs
@@ -10,8 +10,8 @@ module React.Basic.Compat
 import Prelude
 
 import Effect (Effect)
-import React.Basic (ReactComponent, StateUpdate(..), createComponent, send, toReactComponent)
-import React.Basic (JSX, element, elementKeyed, empty, fragment, keyed) as CompatibleTypes
+import React.Basic (ReactComponent, createComponent, toReactComponent)
+import React.Basic (JSX, Self, element, elementKeyed, empty, fragment, keyed) as CompatibleTypes
 
 type Component = ReactComponent
 
@@ -19,33 +19,26 @@ type Component = ReactComponent
 component
   :: forall props state
    . { displayName :: String
-     , initialState :: { | state }
-     , receiveProps :: { props :: { | props }, state :: { | state }, setState :: ({ | state } -> { | state }) -> Effect Unit } -> Effect Unit
-     , render :: { props :: { | props }, state :: { | state }, setState :: ({ | state } -> { | state }) -> Effect Unit } -> CompatibleTypes.JSX
+     , initialState :: {| state }
+     , receiveProps :: CompatibleTypes.Self {| props } {| state } -> Effect Unit
+     , render :: CompatibleTypes.Self {| props } {| state } -> CompatibleTypes.JSX
      }
-  -> ReactComponent { | props }
+  -> ReactComponent {| props }
 component { displayName, initialState, receiveProps, render } =
   toReactComponent identity (createComponent displayName)
     { initialState: initialState
-    , didMount: receiveProps <<< selfToLegacySelf
-    , didUpdate: const <<< receiveProps <<< selfToLegacySelf
-    , update: \self stateUpdate -> Update (stateUpdate self.state)
-    , render: render <<< selfToLegacySelf
+    , didMount: receiveProps
+    , didUpdate: const <<< receiveProps
+    , render: render
     }
-  where
-    selfToLegacySelf self@{ props, state } =
-      { props
-      , state
-      , setState: send self
-      }
 
 -- | Supports a common subset of the v2 API to ease the upgrade process
 stateless
   :: forall props
    . { displayName :: String
-     , render :: { | props } -> CompatibleTypes.JSX
+     , render :: {| props } -> CompatibleTypes.JSX
      }
-  -> ReactComponent { | props }
+  -> ReactComponent {| props }
 stateless { displayName, render } =
   toReactComponent identity (createComponent displayName)
     { render: \self -> render self.props

--- a/src/React/Basic/DOM.purs
+++ b/src/React/Basic/DOM.purs
@@ -93,7 +93,7 @@ foreign import unmountComponentAtNode_ :: EffectFn1 Element Boolean
 -- | `React.Basic.DOM.Components.Ref` where possible__
 -- |
 -- | __*Note:* Relies on `ReactDOM.findDOMNode`__
-findDOMNode :: ReactComponentInstance -> Effect (Either Error Node)
+findDOMNode :: forall props state. ReactComponentInstance props state -> Effect (Either Error Node)
 findDOMNode instance_ = try do
   node <- runEffectFn1 findDOMNode_ instance_
   case toMaybe node of
@@ -101,7 +101,7 @@ findDOMNode instance_ = try do
     Just n  -> pure n
 
 -- | Warning: Relies on `ReactDOM.findDOMNode` which may throw exceptions
-foreign import findDOMNode_ :: EffectFn1 ReactComponentInstance (Nullable Node)
+foreign import findDOMNode_ :: forall props state. EffectFn1 (ReactComponentInstance props state) (Nullable Node)
 
 -- | Divert a render tree into a separate DOM node. The node's
 -- | content will be overwritten and managed by React, similar

--- a/src/React/Basic/DOM/Events.purs
+++ b/src/React/Basic/DOM/Events.purs
@@ -1,7 +1,9 @@
 -- | This module defines safe DOM event function and property accessors.
 
 module React.Basic.DOM.Events
-  ( bubbles
+  ( capture
+  , capture_
+  , bubbles
   , cancelable
   , eventPhase
   , eventPhaseNone
@@ -45,11 +47,27 @@ import Prelude
 
 import Data.Maybe (Maybe)
 import Data.Nullable (toMaybe)
+import Effect (Effect)
 import Effect.Unsafe (unsafePerformEffect)
-import React.Basic.Events (EventFn, SyntheticEvent, unsafeEventFn)
+import React.Basic.Events (EventFn, EventHandler, SyntheticEvent, handler, unsafeEventFn)
 import Unsafe.Coerce (unsafeCoerce)
 import Web.Event.Internal.Types (Event, EventTarget)
 import Web.File.FileList (FileList)
+
+-- | Create a capturing\* `EventHandler` to send an action when an event occurs. For
+-- | more complicated event handlers requiring `Effect`, use `handler` from `React.Basic.Events`.
+-- |
+-- | __\*calls `preventDefault` and `stopPropagation`__
+-- |
+-- | __*See also:* `update`, `capture_`, `monitor`, `React.Basic.Events`__
+capture :: forall a. EventFn SyntheticEvent a -> (a -> Effect Unit) -> EventHandler
+capture eventFn = handler (preventDefault >>> stopPropagation >>> eventFn)
+
+-- | Like `capture`, but for actions which don't need to extract information from the Event.
+-- |
+-- | __*See also:* `update`, `capture`, `monitor_`__
+capture_ :: Effect Unit -> EventHandler
+capture_ cb = capture identity \_ -> cb
 
 -- | General event fields
 


### PR DESCRIPTION
We've been finding the update/action pattern to be too verbose for basic use cases. There was also a bug with type checking actions correctly (#71). This update keeps the current types and lifecycle code while returning state updates to the more traditional `setState` and `setStateThen`.