### PR TITLE
Fix module-level reference to "window"

### DIFF
--- a/src/React/Basic/DOM/Components/GlobalEvents.js
+++ b/src/React/Basic/DOM/Components/GlobalEvents.js
@@ -88,3 +88,11 @@ GlobalEvent.prototype.render = function() {
 };
 
 exports.globalEvent_ = GlobalEvent;
+
+exports.unsafeWindowEventTarget = (function() {
+  if (typeof window === "undefined") {
+    return undefined;
+  } else {
+    return window;
+  }
+})();

--- a/src/React/Basic/DOM/Components/GlobalEvents.purs
+++ b/src/React/Basic/DOM/Components/GlobalEvents.purs
@@ -35,12 +35,9 @@ import Prelude
 
 import Data.Foldable (foldr)
 import Effect (Effect)
-import Effect.Unsafe (unsafePerformEffect)
 import React.Basic (JSX, ReactComponent, element)
 import Web.Event.Event (EventType)
 import Web.Event.Internal.Types (Event, EventTarget)
-import Web.HTML (window)
-import Web.HTML.Window as Window
 
 type EventHandlerOptions =
   { capture :: Boolean
@@ -100,7 +97,7 @@ windowEvents
        }
   -> JSX
   -> JSX
-windowEvents = globalEvents $ unsafePerformEffect $ map Window.toEventTarget window
+windowEvents = globalEvents unsafeWindowEventTarget
 
 windowEvent
   :: { eventType :: EventType
@@ -110,6 +107,8 @@ windowEvent
   -> JSX
   -> JSX
 windowEvent = windowEvents <<< pure
+
+foreign import unsafeWindowEventTarget :: EventTarget
 
 -- | Hide "unused ffi export" warning.
 -- | The export is required to prevent


### PR DESCRIPTION
A module-level `window` reference prevents the use of this library in server- and static-rendering.