### PR TITLE
Drop typelevel-prelude dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,6 @@
     "purescript-functions": "^4.0.0",
     "purescript-nullable": "^4.1.0",
     "purescript-record": "^1.0.0",
-    "purescript-typelevel-prelude": "^3.0.0",
     "purescript-unsafe-coerce": "^4.0.0",
     "purescript-web-dom": "^1.0.0",
     "purescript-web-html": "^1.0.0",

--- a/src/React/Basic.purs
+++ b/src/React/Basic.purs
@@ -29,7 +29,7 @@ import Data.Function.Uncurried (Fn2, mkFn2, runFn2)
 import Data.Nullable (Nullable, notNull, null)
 import Effect (Effect)
 import Effect.Uncurried (EffectFn3, runEffectFn3)
-import Type.Row (class Union)
+import Prim.Row (class Union)
 
 -- | `ComponentSpec` represents a React-Basic component implementation.
 -- |

--- a/src/React/Basic/Events.purs
+++ b/src/React/Basic/Events.purs
@@ -19,7 +19,7 @@ import Effect.Uncurried (EffectFn1, mkEffectFn1)
 import Prim.Row as Row
 import Prim.RowList (kind RowList, class RowToList, Cons, Nil)
 import Record (delete, get, insert)
-import Type.Row (RLProxy(..))
+import Type.Data.RowList (RLProxy(..))
 
 -- | An event handler, which receives a `SyntheticEvent` and performs some
 -- | effects in return.


### PR DESCRIPTION
We aren't actually using anything provided by typelevel-prelude;
instead, we're only using its re-exports. Dropping the dependency and
importing RLProxy and the Union class from where they are defined means
that we have fewer dependencies to worry about, so version
incompatibilities are less likely to occur.

I'd suggest releasing this as a patch-level change; previously we have
recommended releasing changes in which dependencies have been dropped as
major-level, because it can break downstream libraries if they are
relying on the presence of that dependency, but I have come to believe
that this policy is worse since it results in far too many unnecessary
major version bumps, and downstream libraries depending on a particular
transitive dependency but not declaring that dependency are arguably
broken anyway.