### PR TITLE
makeStateless docs

### DIFF
--- a/src/React/Basic.purs
+++ b/src/React/Basic.purs
@@ -245,9 +245,9 @@ foreign import make
 -- | ```
 -- |
 -- | __*Note:* The only difference between a stateless React-Basic component and
--- |   a plain `props -> JSX` function is the presense of the component name
+-- |   a plain `Props -> JSX` function is the presense of the component name
 -- |   in React's dev tools and error stacks. It's just a conceptual boundary.
--- |   If this isn't important simply write a `props -> JSX` function.__
+-- |   If this isn't important simply write a `Props -> JSX` function.__
 -- |
 -- | __*See also:* `make`, `createComponent`, `Component`, `ComponentSpec`__
 makeStateless

--- a/src/React/Basic.purs
+++ b/src/React/Basic.purs
@@ -245,7 +245,7 @@ foreign import make
 -- | ```
 -- |
 -- | __*Note:* The only difference between a stateless React-Basic component and
--- |   a plain `Props -> JSX` function is the presense of the component name
+-- |   a plain `Props -> JSX` function is the presence of the component name
 -- |   in React's dev tools and error stacks. It's just a conceptual boundary.
 -- |   If this isn't important simply write a `Props -> JSX` function.__
 -- |


### PR DESCRIPTION
Capitalize `Props` in `Props -> JSX`.

This signature is a type, and if refers the to type `Props` with a capital `P`, right?