### PR TITLE
Add a helper that coerces an array of JSX to a JSX

### DIFF
--- a/src/React/Basic.purs
+++ b/src/React/Basic.purs
@@ -11,6 +11,7 @@ module React.Basic
   , makeStateless
   , JSX
   , empty
+  , fromArray
   , keyed
   , fragment
   , element
@@ -36,6 +37,7 @@ import Data.Nullable (Nullable, notNull, null)
 import Effect (Effect)
 import Effect.Uncurried (EffectFn3, runEffectFn3)
 import Prim.Row (class Union)
+import Unsafe.Coerce (unsafeCoerce)
 
 -- | `ComponentSpec` represents a React-Basic component implementation.
 -- |
@@ -285,6 +287,13 @@ instance monoidJSX :: Monoid JSX where
 -- |
 -- | __*See also:* `JSX`, Monoid `guard`__
 foreign import empty :: JSX
+
+-- | Coerce an array of `JSX` as a `JSX` itself. Note that when working with nested
+-- | Arrays of JSX, it is important to set the key for child components.
+-- |
+-- | __*See also:* `keyed`, `elementKeyed`, `fragment`__
+fromArray :: Array JSX -> JSX
+fromArray = unsafeCoerce
 
 -- | Apply a React key to a subtree. React-Basic usually hides React's warning about
 -- | using `key` props on components in an Array, but keys are still important for


### PR DESCRIPTION
An array of JSX can also be considered as a JSX.

For some react-basic bindings I'm working on, I've been experimenting with marking the `children` as plain `JSX` (not `Array JSX`). That allows me to skip the array wrapper when working with nodes with a single child. Then for those that need multiple child nodes, I use `fromArray` as defined in this pull req. This practice also aligns more with typescript types for children.

Using this might introduce `key` warnings for users when writing nested arrays -- but perhaps rightfully so.